### PR TITLE
newlines filter: use paragraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bower_components/
 .idea/
 build/
 coverage/
+.vscode/

--- a/src/filters/ofNewLines.filter.js
+++ b/src/filters/ofNewLines.filter.js
@@ -3,7 +3,15 @@ angular
     .filter('ofNewLines', ofNewLines);
 
 function ofNewLines() {
-    return function (input) {
+    return function (input, opts) {
+        var useParagraphs = (opts && opts.useParagraphs) || false;
+        if (useParagraphs === true || useParagraphs === 'true') {
+            return replaceWithPs(input);
+        }
+        return replaceWithBrs(input);
+    };
+
+    function replaceWithBrs(input) {
         // Replace all single or repeated newlines and single or repeated `<br/>`, `<br />` or `<br>` tags by a double `<br />`.
         if (input) {
             // `\n` to `<br />`, will be picked up on the next line
@@ -12,5 +20,20 @@ function ofNewLines() {
             input = input.replace(/(<br\s*\/?>\s*){1,}/gi, '<br /><br />');
         }
         return input;
-    };
+    }
+
+    function replaceWithPs(input) {
+        var normString = replaceWithBrs(input) || '';
+        normString = normString.replace(/(?:<\s{0,}br\s{0,}\/\s{0,}>)/gi, '<br>'); // <br /> --> <br>
+        normString = normString.replace(/(?:<br>\s{0,}){1,}/gi, '</p><p>'); // <br> --> </p><p>
+        normString = normString.replace(/^<\/p><p>/gi, '<p>');
+        normString = normString.replace(/<\/p><p>$/gi, '</p>');
+        if (normString.substring(0, 3) !== '<p>') {
+            normString = '<p>' + normString;
+        }
+        if (normString.substring(normString.length - 4, normString.length) !== '</p>') {
+            normString = normString + '</p>';
+        }
+        return normString;
+    }
 }

--- a/test/spec/filters/ofNewLines.filter.spec.js
+++ b/test/spec/filters/ofNewLines.filter.spec.js
@@ -21,5 +21,24 @@
             var result = 'some text <br /><br />';
             expect (newlines(input)).toEqual(result);
         });
+
+        it('uses <p> elements 1', function () {
+            var input = 'some text <br> <br> <br> <br> <br>';
+            var result = '<p>some text </p>';
+            expect(newlines(input, { useParagraphs: true })).toEqual(result);
+        });
+
+        it('uses <p> elements 2', function () {
+            var input = 'some text <br> <br> <br> <br> <br>some text \n\n\n some text\n\n\n';
+            var result = '<p>some text </p><p>some text </p><p>some text</p>';
+            expect(newlines(input, { useParagraphs: true })).toEqual(result);
+        });
+
+        it('uses <p> elements 3', function () {
+            var input = '\n\n\n\n\n\n some text <br> <br> <br> <br> <br>some text \n\n\n some text';
+            var result = '<p>some text </p><p>some text </p><p>some text</p>';
+            expect(newlines(input, { useParagraphs: true })).toEqual(result);
+        });
+
     });
 }) ();


### PR DESCRIPTION
Add an options to the `newlines` filter in order to produce `<p>` elements (instead of `<br>`s).